### PR TITLE
fix(helm-docs): temporarily switch to version compatible with go 1.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:alpine3.17 AS builder
 ENV GO111MODULE=on
-RUN go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest
+RUN go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.12.0
 
 FROM alpine:3.17
 COPY docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
updated Dockerfile with low-impact change to handle failed docker build due to: 
go install github.com/norwoodj/helm-docs/cmd/helm-docs@latest requiring go 1.22