### PR TITLE
chore: pin actions to SHA, update to latest versions, security-only dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,8 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: daily
+      interval: "weekly"
+    open-pull-requests-limit: 0
 
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: daily

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,20 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - id: version
         name: Determine next version
-        uses: conventional-actions/next-version@v1
+        uses: conventional-actions/next-version@e48c1275d221bd29e2c08f8856b91695c0a72db1 # v1.1.6
       - name: Create release
-        uses: conventional-actions/create-release@v1
+        uses: conventional-actions/create-release@50cd05b8ea9f2f3f32bbb822706b01ebf2ccce62 # v1.0.29
         with:
           tag_name: ${{steps.version.outputs.version}}
       - name: Create major release
-        uses: conventional-actions/create-release@v1
+        uses: conventional-actions/create-release@50cd05b8ea9f2f3f32bbb822706b01ebf2ccce62 # v1.0.29
         with:
           tag_name: ${{steps.version.outputs.version-major}}
 
 permissions:
   contents: write
+


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to verified commit SHAs (supply-chain security hardening)
- Update `actions/checkout` from v4 tag to v6.0.2 (SHA-pinned)
- Update `conventional-actions/next-version` to v1.1.6 (SHA-pinned)
- Update `conventional-actions/create-release` to v1.0.29 (SHA-pinned)
- Configure dependabot for **security updates only** (`open-pull-requests-limit: 0`)
- Remove npm ecosystem from dependabot (not applicable for this action type)

## Security

All SHAs verified via `gh api repos/REPO/git/ref/tags/TAG`.

## Test plan

- [ ] CI release workflow passes on merge
- [ ] Verify dependabot only creates security alert PRs (no version bump PRs)
