### PR TITLE
feat!: Update base images and helm-docs to v1.14.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: 'release'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
@@ -7,6 +11,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,7 +30,3 @@ jobs:
         uses: conventional-actions/create-release@50cd05b8ea9f2f3f32bbb822706b01ebf2ccce62 # v1.0.29
         with:
           tag_name: ${{steps.version.outputs.version-major}}
-
-permissions:
-  contents: write
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:alpine3.17 AS builder
+FROM golang:alpine3.21 AS builder
 ENV GO111MODULE=on
-RUN go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.12.0
+RUN go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.14.2
 
-FROM alpine:3.17
+FROM alpine:3.21
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 COPY --from=builder /go/bin/helm-docs /usr/local/bin/helm-docs
 ENTRYPOINT ["/docker-entrypoint.sh"]


### PR DESCRIPTION
## Summary
- `golang:alpine3.17` → `golang:alpine3.21`
- `alpine:3.17` → `alpine:3.21`
- `helm-docs@v1.12.0` → `helm-docs@v1.14.2`
- `release.yml`: concurrency, `timeout-minutes`, job permissions

## BREAKING CHANGE
New helm-docs version may alter generated README content.